### PR TITLE
 change fasterxml.version to 2.8.4, otherwise it will cause 'no such  … method exception' when starting.

### DIFF
--- a/kafka-eagle-common/pom.xml
+++ b/kafka-eagle-common/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>kafka-eagle-common</artifactId>
 
 	<properties>
-		<fasterxml.version>2.9.5</fasterxml.version>
+		<fasterxml.version>2.8.4</fasterxml.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION

change fasterxml.version to 2.8.4, otherwise it will cause 'no such  …
method exception' when starting.