### PR TITLE
添加Email发送支持SSL

### DIFF
--- a/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/email/MailFactory.java
+++ b/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/email/MailFactory.java
@@ -24,7 +24,7 @@ package org.smartloli.kafka.eagle.api.email;
  *
  *         Created by Jan 17, 2017
  * 
- * @see org.smartloli.kafka.eagle.factory.MailProvider
+ * @see org.smartloli.kafka.eagle.api.email.MailProvider
  */
 public class MailFactory implements MailProvider {
 

--- a/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/email/MailProvider.java
+++ b/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/email/MailProvider.java
@@ -27,5 +27,5 @@ package org.smartloli.kafka.eagle.api.email;
  * @see org.smartloli.kafka.eagle.api.email.MailService
  */
 public interface MailProvider {
-	public MailService create();
+	MailService create();
 }

--- a/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/email/MailService.java
+++ b/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/email/MailService.java
@@ -26,6 +26,6 @@ package org.smartloli.kafka.eagle.api.email;
  */
 public interface MailService {
 
-	public boolean send(String subject, String address, String content, String attachment);
+	boolean send(String subject, String address, String content, String attachment);
 
 }

--- a/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/im/IMProvider.java
+++ b/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/im/IMProvider.java
@@ -27,5 +27,5 @@ package org.smartloli.kafka.eagle.api.im;
  * @see org.smartloli.kafka.eagle.api.im.IMService
  */
 public interface IMProvider {
-	public IMService create();
+	IMService create();
 }

--- a/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/im/IMService.java
+++ b/kafka-eagle-api/src/main/java/org/smartloli/kafka/eagle/api/im/IMService.java
@@ -26,8 +26,8 @@ package org.smartloli.kafka.eagle.api.im;
  */
 public interface IMService {
 
-	public void sendJsonMsgByDingDing(String data);
+	void sendJsonMsgByDingDing(String data);
 	
-	public void sendJsonMsgByWeChat(String data);
+	void sendJsonMsgByWeChat(String data);
 	
 }

--- a/kafka-eagle-common/src/main/resources/system-config.properties
+++ b/kafka-eagle-common/src/main/resources/system-config.properties
@@ -42,6 +42,7 @@ kafka.eagle.sql.topic.records.max=5000
 # alarm email configure
 ######################################
 kafka.eagle.mail.enable=false
+kafka.eagle.mail.ssl.enable=false
 kafka.eagle.mail.sa=alert_sa
 kafka.eagle.mail.username=alert_sa@126.com
 kafka.eagle.mail.password=smartloli

--- a/kafka-eagle-web/src/main/resources/conf/system-config.properties
+++ b/kafka-eagle-web/src/main/resources/conf/system-config.properties
@@ -36,6 +36,7 @@ kafka.eagle.sql.topic.records.max=5000
 # alarm email configure
 ######################################
 kafka.eagle.mail.enable=false
+kafka.eagle.mail.ssl.enable=false
 kafka.eagle.mail.sa=alert_sa
 kafka.eagle.mail.username=alert_sa@163.com
 kafka.eagle.mail.password=mqslimczkdqabbbh


### PR DESCRIPTION
1. 添加Email发送支持SSL
2. 接口方法默认public abstract 修饰，可省略