### PR TITLE
Replace com.mysql.jdbc.Driver with com.mysql.cj.jdbc.Driver

### DIFF
--- a/kafka-eagle-common/src/main/resources/system-config.properties
+++ b/kafka-eagle-common/src/main/resources/system-config.properties
@@ -113,7 +113,7 @@ cluster1.kafka.eagle.ssl.cgroup.topics=
 ######################################
 # kafka jdbc driver address
 ######################################
-kafka.eagle.driver=com.mysql.jdbc.Driver
+kafka.eagle.driver=com.mysql.cj.jdbc.Driver
 kafka.eagle.url=jdbc:mysql://127.0.0.1:3306/ke?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
 kafka.eagle.username=root
 kafka.eagle.password=123456


### PR DESCRIPTION
Based on mysql-connector-java-8.0.21, the default mysql jdbc driver configuration should be com.mysql.cj.jdbc.Driver.

When I use the MySQL database to run program prompts that the jdbc driver class cannot be found. I found that the mysql driver uses version 8.0, while the configuration uses the 5.X version of the driver class.

By default, dependencies and configuration should be kept in sync with versions.